### PR TITLE
Fix the import to use golang.org/x instead of code.google.com/p/go.

### DIFF
--- a/box/box.go
+++ b/box/box.go
@@ -10,8 +10,8 @@ import (
 	"errors"
 	"io"
 
-	"code.google.com/p/go.crypto/curve25519"
-	"code.google.com/p/go.crypto/poly1305"
+	"golang.org/x/crypto/curve25519"
+	"golang.org/x/crypto/poly1305"
 	"github.com/titanous/chacha20"
 )
 


### PR DESCRIPTION
Not a big change, but this is need to build the package using a current Go installation.