### PR TITLE
Add the AES256-GCM ciphersuite.

### DIFF
--- a/box/aes256gcm.go
+++ b/box/aes256gcm.go
@@ -1,0 +1,104 @@
+package box
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/binary"
+	"io"
+
+	"golang.org/x/crypto/curve25519"
+)
+
+var Noise255AES256GCM = aes256gcm{}
+
+type aes256gcm struct{}
+
+func (aes256gcm) AppendName(dst []byte) []byte {
+	return append(dst, "Noise255/AES256-GCM\x00\x00\x00\x00\x00"...)
+}
+
+func (aes256gcm) DHLen() int  { return 32 }
+func (aes256gcm) CCLen() int  { return 44 }
+func (aes256gcm) MACLen() int { return 16 }
+
+func (aes256gcm) GenerateKey(random io.Reader) (Key, error) {
+	var pubKey, privKey [32]byte
+	if random == nil {
+		random = rand.Reader
+	}
+	if _, err := io.ReadFull(random, privKey[:]); err != nil {
+		return Key{}, err
+	}
+	privKey[0] &= 248
+	privKey[31] &= 127
+	privKey[31] |= 64
+	curve25519.ScalarBaseMult(&pubKey, &privKey)
+	return Key{Private: privKey[:], Public: pubKey[:]}, nil
+}
+
+func (aes256gcm) KeyLen() (int, int) {
+	return 32, 32
+}
+
+func (aes256gcm) DH(privkey, pubkey []byte) []byte {
+	var dst, in, base [32]byte
+	copy(in[:], privkey)
+	copy(base[:], pubkey)
+	curve25519.ScalarMult(&dst, &in, &base)
+	return dst[:]
+}
+
+func (aes256gcm) NewCipher(cc []byte) CipherContext {
+	return &aes256gcmctx{cc: cc}
+}
+
+type aes256gcmctx struct {
+	cc     []byte
+	cipher cipher.AEAD
+}
+
+func (ctx *aes256gcmctx) Reset(cc []byte) {
+	ctx.cc = cc
+}
+
+func (ctx *aes256gcmctx) Encrypt(dst, plaintext, authtext []byte) []byte {
+	block, err := aes.NewCipher(ctx.cc[:32])
+	if err != nil {
+		panic(err)
+	}
+	ctx.cipher, err = cipher.NewGCM(block)
+	if err != nil {
+		panic(err)
+	}
+
+	nonce := make([]byte, 12)
+	copy(nonce, ctx.cc[32:44])
+	n := binary.BigEndian.Uint64(ctx.cc[36:44])
+	binary.BigEndian.PutUint64(ctx.cc[36:44], n+1)
+
+	return ctx.cipher.Seal(dst, nonce, plaintext, authtext)
+}
+
+func (ctx *aes256gcmctx) Decrypt(ciphertext, authtext []byte) ([]byte, error) {
+	if len(ciphertext) < 16 {
+		return nil, ErrAuthFailed
+	}
+
+	block, err := aes.NewCipher(ctx.cc[:32])
+	if err != nil {
+		panic(err)
+	}
+	ctx.cipher, err = cipher.NewGCM(block)
+	if err != nil {
+		panic(err)
+	}
+
+	nonce := make([]byte, 12)
+	copy(nonce, ctx.cc[32:44])
+	n := binary.BigEndian.Uint64(ctx.cc[36:44])
+	binary.BigEndian.PutUint64(ctx.cc[36:44], n+1)
+
+	plaintext := make([]byte, 0, len(ciphertext)-ctx.cipher.Overhead())
+	return ctx.cipher.Open(plaintext, nonce, ciphertext, authtext)
+}

--- a/box/aes256gcm_test.go
+++ b/box/aes256gcm_test.go
@@ -1,0 +1,88 @@
+package box
+
+import (
+	"encoding/hex"
+
+	. "gopkg.in/check.v1"
+)
+
+func (s *S) TestRoundtripAES256(c *C) {
+	enc, dec := newCryptersAES256()
+
+	plain := []byte("yellow submarines")
+	padLen := 2
+	ciphertext, err := enc.EncryptBox(nil, nil, plain, padLen, 0)
+	c.Assert(err, IsNil)
+
+	expectedLen := len(plain) + padLen + (2 * Noise255AES256GCM.DHLen()) + (2 * Noise255AES256GCM.MACLen()) + 4
+	c.Assert(ciphertext, HasLen, expectedLen, Commentf("expected: %d", expectedLen))
+
+	plaintext, err := dec.DecryptBox(ciphertext, 0)
+	c.Assert(err, IsNil)
+	c.Assert(plaintext, DeepEquals, plain)
+
+	plain[0] = 'Y'
+	ciphertext, err = enc.EncryptBox(nil, nil, plain, 0, 1)
+	c.Assert(err, IsNil)
+
+	plaintext, err = dec.DecryptBox(ciphertext, 1)
+	c.Assert(err, IsNil)
+	c.Assert(plaintext, DeepEquals, plain)
+}
+
+func newCryptersAES256() (*Crypter, *Crypter) {
+	recvKey, _ := Noise255AES256GCM.GenerateKey(nil)
+	sendKey, _ := Noise255AES256GCM.GenerateKey(nil)
+
+	enc := &Crypter{
+		Cipher:  Noise255AES256GCM,
+		Key:     sendKey,
+		PeerKey: recvKey,
+	}
+	enc.PeerKey.Private = nil
+
+	dec := &Crypter{
+		Cipher:  Noise255AES256GCM,
+		Key:     recvKey,
+		PeerKey: sendKey,
+	}
+	dec.PeerKey.Private = nil
+
+	return enc, dec
+}
+
+func (s *S) TestEncryptAES256GCM(c *C) {
+	key, _ := hex.DecodeString("4C973DBC7364621674F8B5B89E5C15511FCED9216490FB1C1A2CAA0FFE0407E5")
+	plaintext, _ := hex.DecodeString("08000F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748490008")
+	authData, _ := hex.DecodeString("68F2E77696CE7AE8E2CA4EC588E54D002E58495C")
+	iv, _ := hex.DecodeString("7AE8E2CA4EC500012E58495C")
+
+	expectedCiphertext, _ := hex.DecodeString("BA8AE31BC506486D6873E4FCE460E7DC57591FF00611F31C3834FE1C04AD80B66803AFCF5B27E6333FA67C99DA47C2F0CED68D531BD741A943CFF7A6713BD0")
+	expectedTag, _ := hex.DecodeString("2611CD7DAA01D61C5C886DC1A8170107")
+
+	expected := append(expectedCiphertext, expectedTag...)
+
+	cc := append(key, iv...)
+	crypter := Noise255AES256GCM.NewCipher(cc)
+
+	dst := crypter.Encrypt(nil, plaintext, authData)
+	c.Assert(dst, DeepEquals, expected)
+}
+
+func (s *S) TestDecryptAES256GCM(c *C) {
+	key, _ := hex.DecodeString("4C973DBC7364621674F8B5B89E5C15511FCED9216490FB1C1A2CAA0FFE0407E5")
+	ciphertext, _ := hex.DecodeString("BA8AE31BC506486D6873E4FCE460E7DC57591FF00611F31C3834FE1C04AD80B66803AFCF5B27E6333FA67C99DA47C2F0CED68D531BD741A943CFF7A6713BD0")
+	tag, _ := hex.DecodeString("2611CD7DAA01D61C5C886DC1A8170107")
+	authData, _ := hex.DecodeString("68F2E77696CE7AE8E2CA4EC588E54D002E58495C")
+	iv, _ := hex.DecodeString("7AE8E2CA4EC500012E58495C")
+
+	ciphertext = append(ciphertext, tag...)
+	expectedPlaintext, _ := hex.DecodeString("08000F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748490008")
+
+	cc := append(key, iv...)
+	crypter := Noise255AES256GCM.NewCipher(cc)
+
+	dst, err := crypter.Decrypt(ciphertext, authData)
+	c.Assert(err, IsNil)
+	c.Assert(dst, DeepEquals, expectedPlaintext)
+}

--- a/box/box.go
+++ b/box/box.go
@@ -1,7 +1,6 @@
 package box
 
 import (
-	"crypto/cipher"
 	"crypto/hmac"
 	"crypto/rand"
 	"crypto/sha512"
@@ -9,10 +8,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
-
-	"golang.org/x/crypto/curve25519"
-	"golang.org/x/crypto/poly1305"
-	"github.com/titanous/chacha20"
 )
 
 type Ciphersuite interface {
@@ -32,6 +27,8 @@ type CipherContext interface {
 	Encrypt(dst, plaintext, authtext []byte) []byte
 	Decrypt(ciphertext, authtext []byte) ([]byte, error)
 }
+
+var ErrAuthFailed = errors.New("box: message authentication failed")
 
 const CVLen = 48
 
@@ -185,146 +182,4 @@ func DeriveKey(secret, extra, info []byte, outputLen int) []byte {
 		}
 	}
 	return output
-}
-
-var Noise255 = noise255{}
-
-type noise255 struct{}
-
-func (noise255) AppendName(dst []byte) []byte {
-	return append(dst, "Noise255\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"...)
-}
-func (noise255) DHLen() int  { return 32 }
-func (noise255) CCLen() int  { return 40 }
-func (noise255) MACLen() int { return 16 }
-
-func (noise255) GenerateKey(random io.Reader) (Key, error) {
-	var pubKey, privKey [32]byte
-	if random == nil {
-		random = rand.Reader
-	}
-	if _, err := io.ReadFull(random, privKey[:]); err != nil {
-		return Key{}, err
-	}
-	privKey[0] &= 248
-	privKey[31] &= 127
-	privKey[31] |= 64
-	curve25519.ScalarBaseMult(&pubKey, &privKey)
-	return Key{Private: privKey[:], Public: pubKey[:]}, nil
-}
-
-func (noise255) KeyLen() (int, int) {
-	return 32, 32
-}
-
-func (noise255) DH(privkey, pubkey []byte) []byte {
-	var dst, in, base [32]byte
-	copy(in[:], privkey)
-	copy(base[:], pubkey)
-	curve25519.ScalarMult(&dst, &in, &base)
-	return dst[:]
-}
-
-func (noise255) NewCipher(cc []byte) CipherContext {
-	return &noise255ctx{cc: cc}
-}
-
-type noise255ctx struct {
-	cc        []byte
-	keystream [168]byte
-	cipher    chacha20.Cipher
-}
-
-func (n *noise255ctx) Reset(cc []byte) {
-	n.cc = cc
-}
-
-func (n *noise255ctx) key() (cipher.Stream, []byte) {
-	cipherKey := n.cc[:32]
-	iv := n.cc[32:40]
-
-	if err := n.cipher.Initialize(cipherKey, iv); err != nil {
-		panic(err)
-	}
-
-	keystream := n.keystream[:64]
-	for i := range keystream {
-		n.keystream[i] = 0
-	}
-	n.cipher.XORKeyStream(keystream, keystream)
-
-	return &n.cipher, keystream
-}
-
-func (n *noise255ctx) rekey() {
-	cipherKey := n.cc[:32]
-	iv := n.cc[32:40]
-	for i := range iv {
-		iv[i] ^= 0xff
-	}
-	if err := n.cipher.Initialize(cipherKey, iv); err != nil {
-		panic(err)
-	}
-
-	ks := n.keystream[64:]
-	for i := range ks {
-		ks[i] = 0
-	}
-	n.cipher.XORKeyStream(ks, ks)
-	n.cc = ks[64:]
-}
-
-func (n *noise255ctx) mac(keystream, ciphertext, authtext []byte) [16]byte {
-	var macKey [32]byte
-	var tag [16]byte
-	copy(macKey[:], keystream)
-	poly1305.Sum(&tag, n.authData(ciphertext, authtext), &macKey)
-	return tag
-}
-
-func (n *noise255ctx) Encrypt(dst, plaintext, authtext []byte) []byte {
-	c, keystream := n.key()
-	ciphertext := make([]byte, len(plaintext), len(plaintext)+16)
-	c.XORKeyStream(ciphertext, plaintext)
-	n.rekey()
-	tag := n.mac(keystream, ciphertext, authtext)
-	return append(dst, append(ciphertext, tag[:]...)...)
-}
-
-var ErrAuthFailed = errors.New("box: message authentication failed")
-
-func (n *noise255ctx) Decrypt(ciphertext, authtext []byte) ([]byte, error) {
-	if len(ciphertext) < 16 {
-		return nil, ErrAuthFailed
-	}
-	digest := ciphertext[len(ciphertext)-16:]
-	ciphertext = ciphertext[:len(ciphertext)-16]
-	c, keystream := n.key()
-	tag := n.mac(keystream, ciphertext, authtext)
-
-	if subtle.ConstantTimeCompare(digest, tag[:]) != 1 {
-		return nil, ErrAuthFailed
-	}
-
-	plaintext := make([]byte, len(ciphertext))
-	c.XORKeyStream(plaintext, ciphertext)
-	n.rekey()
-	return plaintext, nil
-}
-
-func (noise255ctx) authData(ciphertext, authtext []byte) []byte {
-	// PAD16(authtext) || PAD16(ciphertext) || (uint64_little_endian)len(authtext) || (uint64_little_endian)len(ciphertext)
-	authData := make([]byte, pad16len(len(authtext))+pad16len(len(ciphertext))+8+8)
-	copy(authData, authtext)
-	offset := pad16len(len(authtext))
-	copy(authData[offset:], ciphertext)
-	offset += pad16len(len(ciphertext))
-	binary.LittleEndian.PutUint64(authData[offset:], uint64(len(authtext)))
-	offset += 8
-	binary.LittleEndian.PutUint64(authData[offset:], uint64(len(ciphertext)))
-	return authData
-}
-
-func pad16len(l int) int {
-	return l + ((16 - (l % 16)) % 16)
 }

--- a/box/noise255.go
+++ b/box/noise255.go
@@ -1,0 +1,153 @@
+package box
+
+import (
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/binary"
+	"io"
+
+	"golang.org/x/crypto/curve25519"
+	"golang.org/x/crypto/poly1305"
+	"github.com/titanous/chacha20"
+)
+
+var Noise255 = noise255{}
+
+type noise255 struct{}
+
+func (noise255) AppendName(dst []byte) []byte {
+	return append(dst, "Noise255\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"...)
+}
+func (noise255) DHLen() int  { return 32 }
+func (noise255) CCLen() int  { return 40 }
+func (noise255) MACLen() int { return 16 }
+
+func (noise255) GenerateKey(random io.Reader) (Key, error) {
+	var pubKey, privKey [32]byte
+	if random == nil {
+		random = rand.Reader
+	}
+	if _, err := io.ReadFull(random, privKey[:]); err != nil {
+		return Key{}, err
+	}
+	privKey[0] &= 248
+	privKey[31] &= 127
+	privKey[31] |= 64
+	curve25519.ScalarBaseMult(&pubKey, &privKey)
+	return Key{Private: privKey[:], Public: pubKey[:]}, nil
+}
+
+func (noise255) KeyLen() (int, int) {
+	return 32, 32
+}
+
+func (noise255) DH(privkey, pubkey []byte) []byte {
+	var dst, in, base [32]byte
+	copy(in[:], privkey)
+	copy(base[:], pubkey)
+	curve25519.ScalarMult(&dst, &in, &base)
+	return dst[:]
+}
+
+func (noise255) NewCipher(cc []byte) CipherContext {
+	return &noise255ctx{cc: cc}
+}
+
+type noise255ctx struct {
+	cc        []byte
+	keystream [168]byte
+	cipher    chacha20.Cipher
+}
+
+func (n *noise255ctx) Reset(cc []byte) {
+	n.cc = cc
+}
+
+func (n *noise255ctx) key() (cipher.Stream, []byte) {
+	cipherKey := n.cc[:32]
+	iv := n.cc[32:40]
+
+	if err := n.cipher.Initialize(cipherKey, iv); err != nil {
+		panic(err)
+	}
+
+	keystream := n.keystream[:64]
+	for i := range keystream {
+		n.keystream[i] = 0
+	}
+	n.cipher.XORKeyStream(keystream, keystream)
+
+	return &n.cipher, keystream
+}
+
+func (n *noise255ctx) rekey() {
+	cipherKey := n.cc[:32]
+	iv := n.cc[32:40]
+	for i := range iv {
+		iv[i] ^= 0xff
+	}
+	if err := n.cipher.Initialize(cipherKey, iv); err != nil {
+		panic(err)
+	}
+
+	ks := n.keystream[64:]
+	for i := range ks {
+		ks[i] = 0
+	}
+	n.cipher.XORKeyStream(ks, ks)
+	n.cc = ks[64:]
+}
+
+func (n *noise255ctx) mac(keystream, ciphertext, authtext []byte) [16]byte {
+	var macKey [32]byte
+	var tag [16]byte
+	copy(macKey[:], keystream)
+	poly1305.Sum(&tag, n.authData(ciphertext, authtext), &macKey)
+	return tag
+}
+
+func (n *noise255ctx) Encrypt(dst, plaintext, authtext []byte) []byte {
+	c, keystream := n.key()
+	ciphertext := make([]byte, len(plaintext), len(plaintext)+16)
+	c.XORKeyStream(ciphertext, plaintext)
+	n.rekey()
+	tag := n.mac(keystream, ciphertext, authtext)
+	return append(dst, append(ciphertext, tag[:]...)...)
+}
+
+func (n *noise255ctx) Decrypt(ciphertext, authtext []byte) ([]byte, error) {
+	if len(ciphertext) < 16 {
+		return nil, ErrAuthFailed
+	}
+	digest := ciphertext[len(ciphertext)-16:]
+	ciphertext = ciphertext[:len(ciphertext)-16]
+	c, keystream := n.key()
+	tag := n.mac(keystream, ciphertext, authtext)
+
+	if subtle.ConstantTimeCompare(digest, tag[:]) != 1 {
+		return nil, ErrAuthFailed
+	}
+
+	plaintext := make([]byte, len(ciphertext))
+	c.XORKeyStream(plaintext, ciphertext)
+	n.rekey()
+	return plaintext, nil
+}
+
+func (noise255ctx) authData(ciphertext, authtext []byte) []byte {
+	// PAD16(authtext) || PAD16(ciphertext) || (uint64_little_endian)len(authtext) || (uint64_little_endian)len(ciphertext)
+	authData := make([]byte, pad16len(len(authtext))+pad16len(len(ciphertext))+8+8)
+	copy(authData, authtext)
+	offset := pad16len(len(authtext))
+	copy(authData[offset:], ciphertext)
+	offset += pad16len(len(ciphertext))
+	binary.LittleEndian.PutUint64(authData[offset:], uint64(len(authtext)))
+	offset += 8
+	binary.LittleEndian.PutUint64(authData[offset:], uint64(len(ciphertext)))
+	return authData
+}
+
+func pad16len(l int) int {
+	return l + ((16 - (l % 16)) % 16)
+}


### PR DESCRIPTION
This adds Noise255/AES256-GCM as a second ciphersuite.

Maybe the tests should be re-organized a little bit now, and it should be quite easy to also add the Noise255/AES128-GCM suite.